### PR TITLE
NIP-5D: napplet instancing (shared/isolated/singleton)

### DIFF
--- a/5D.md
+++ b/5D.md
@@ -21,6 +21,8 @@ A napplet is a Nostr applet - a small, focused application that does one thing w
 | dTag | Napplet type identifier from the [NIP-5A](5A.md) manifest `d` tag |
 | Aggregate hash | SHA-256 of napplet build files per [NIP-5A](5A.md) |
 | NAP | Nostr Applet Protocol -- extension spec defining protocol messages for a capability domain |
+| Instance | A single live napplet iframe. Multiple instances of one napplet (same `dTag` + aggregate hash) MAY run concurrently |
+| Instance discriminator | Opaque, shell-internal handle identifying one instance. Host-private; never exposed to the napplet |
 
 ## Transport
 
@@ -55,9 +57,11 @@ Messages with an unrecognized `type` MUST be silently ignored. This allows forwa
 
 The shell assigns napplet identity at iframe creation time. No negotiation is required.
 
-When the shell creates a napplet iframe, it maps the iframe's `Window` reference to the napplet's `(dTag, aggregateHash)` tuple from the [NIP-5A](5A.md) manifest. This mapping is the napplet's identity for the session. How the shell internally represents or derives identity is an implementation detail.
+When the shell creates a napplet iframe, it maps the iframe's `Window` reference to the napplet's `(dTag, aggregateHash)` tuple from the [NIP-5A](5A.md) manifest. This tuple is the napplet's **type identity** — it names the napplet type and version, not a particular running copy. How the shell internally represents or derives identity is an implementation detail.
 
-The shell MUST verify `MessageEvent.source` on every inbound message. Messages from Window references not mapped to a napplet identity MUST be silently dropped.
+A shell MAY run several iframes of the same napplet concurrently (see [Instancing](#instancing)). Each iframe is a distinct **instance** keyed by its own `Window` reference, so many `Window` references MAY map to one type-identity tuple. A shell MAY associate each instance with an opaque **instance discriminator**. This discriminator MUST NOT be exposed to the napplet — not via URL, init message, capability query, or any NAP payload. Napplets MUST remain blind to their own instance, so they stay portable across runtimes.
+
+The shell MUST verify `MessageEvent.source` on every inbound message. Messages from Window references not mapped to a napplet identity MUST be silently dropped. Because verification is per-`Window`, it already distinguishes instances of the same napplet.
 
 ## Manifest and NAP Negotiation
 
@@ -86,6 +90,24 @@ Shells MUST implement `window.napplet.shell.supports()`. The argument is a names
 
 Napplets MUST gracefully degrade when a capability is absent.
 
+## Instancing
+
+A shell MAY run a napplet as zero or more concurrent instances. A napplet declares how it expects to be instanced with an optional `instancing` tag in its [NIP-5A](5A.md) manifest:
+
+    ["instancing", "<mode>"]
+
+| Mode | Meaning |
+|------|---------|
+| `shared` | Many concurrent instances allowed; all share one shell-mediated scope (e.g. one storage namespace). **Default when the tag is absent.** |
+| `isolated` | Many concurrent instances allowed; each instance is scoped independently, partitioned by its opaque instance discriminator (see [Identity](#identity)). |
+| `singleton` | At most one instance at a time. |
+
+Like `requires`, the `instancing` tag is defined by this NIP and carried in the NIP-5A manifest event; the NIP-5A static primitive does not interpret it.
+
+**Shell behavior.** Shells SHOULD honor `singleton`: a request to open a napplet that already has a live instance SHOULD focus or reuse that instance rather than create a second one. Shells MAY honor `isolated`; a shell that does not implement per-instance scoping MUST degrade to `shared` (instances share one scope but remain fully functional). An absent or unrecognized mode MUST be treated as `shared`.
+
+**Transparency.** Instancing is invisible to napplet code. A napplet calls every NAP identically in all modes and MUST NOT be able to observe its mode or its instance discriminator. Within a sandboxed iframe all non-persistent state (memory, relay subscriptions, IFC) is already per-instance; `isolated` extends that property to shell-mediated persistent state. How a NAP scopes per-instance state is defined by that NAP (e.g. NAP-STORAGE).
+
 ## NAP Extension Framework
 
 Protocol messages are defined by NAP (Nostr Applet Protocol) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for envelope format and transport.
@@ -105,7 +127,7 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 **Mitigations:**
 1. Iframe sandbox: `allow-scripts` is the only required token -- shells MUST NOT add `allow-same-origin`. Adding `allow-same-origin` would grant the napplet a real origin, allowing it to register a service worker, read shell `localStorage`, and bypass shell mediation entirely -- this prohibition is the load-bearing precondition for browser-enforced isolation of any kind.
 2. postMessage `'*'` origin is required for opaque-origin iframes; sender identification uses `MessageEvent.source`, NOT `event.origin`.
-3. Identity binding: the shell maps `MessageEvent.source` to napplet identity at iframe creation. The browser's `MessageEvent.source` is unforgeable within the same browsing context.
+3. Identity binding: the shell maps `MessageEvent.source` to napplet identity at iframe creation. The browser's `MessageEvent.source` is unforgeable within the same browsing context. Distinct instances of one napplet present distinct `Window` sources that map to the same type identity; isolation of per-instance state between them is enforced by the consuming NAP using the shell's opaque instance discriminator, which MUST NOT be exposed to napplets.
 4. Aggregate hash verification against [NIP-5A](5A.md) manifests; mismatch MAY result in napplet rejection.
 5. Unrecognized message types are silently ignored, preventing capability probing.
 6. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.

--- a/5D.md
+++ b/5D.md
@@ -21,8 +21,8 @@ A napplet is a Nostr applet - a small, focused application that does one thing w
 | dTag | Napplet type identifier from the [NIP-5A](5A.md) manifest `d` tag |
 | Aggregate hash | SHA-256 of napplet build files per [NIP-5A](5A.md) |
 | NAP | Nostr Applet Protocol -- extension spec defining protocol messages for a capability domain |
-| Instance | A single live napplet iframe. Multiple instances of one napplet (same `dTag` + aggregate hash) MAY run concurrently |
-| Instance discriminator | Opaque, shell-internal handle identifying one instance. Host-private; never exposed to the napplet |
+| Instance | A live napplet iframe. Several instances of one napplet (same `dTag` + aggregate hash) MAY run at once |
+| Instance discriminator | Opaque shell-internal handle for one instance. Never exposed to the napplet |
 
 ## Transport
 
@@ -57,11 +57,11 @@ Messages with an unrecognized `type` MUST be silently ignored. This allows forwa
 
 The shell assigns napplet identity at iframe creation time. No negotiation is required.
 
-When the shell creates a napplet iframe, it maps the iframe's `Window` reference to the napplet's `(dTag, aggregateHash)` tuple from the [NIP-5A](5A.md) manifest. This tuple is the napplet's **type identity** — it names the napplet type and version, not a particular running copy. How the shell internally represents or derives identity is an implementation detail.
+When the shell creates a napplet iframe, it maps the iframe's `Window` reference to the napplet's `(dTag, aggregateHash)` tuple from the [NIP-5A](5A.md) manifest. This tuple is the napplet's **type identity** — its type and version, not a running copy. How the shell derives identity is an implementation detail.
 
-A shell MAY run several iframes of the same napplet concurrently (see [Instancing](#instancing)). Each iframe is a distinct **instance** keyed by its own `Window` reference, so many `Window` references MAY map to one type-identity tuple. A shell MAY associate each instance with an opaque **instance discriminator**. This discriminator MUST NOT be exposed to the napplet — not via URL, init message, capability query, or any NAP payload. Napplets MUST remain blind to their own instance, so they stay portable across runtimes.
+A shell MAY run several iframes of one napplet at once (see [Instancing](#instancing)); each is a distinct **instance** keyed by its own `Window`, so many Windows MAY share one tuple. The shell MAY tag each instance with an opaque **instance discriminator**, which it MUST NOT expose to the napplet (URL, init message, capability query, or any NAP payload). Napplets stay instance-blind to remain portable.
 
-The shell MUST verify `MessageEvent.source` on every inbound message. Messages from Window references not mapped to a napplet identity MUST be silently dropped. Because verification is per-`Window`, it already distinguishes instances of the same napplet.
+The shell MUST verify `MessageEvent.source` on every inbound message and silently drop messages from unmapped Windows. Per-`Window` verification already distinguishes instances.
 
 ## Manifest and NAP Negotiation
 
@@ -92,21 +92,21 @@ Napplets MUST gracefully degrade when a capability is absent.
 
 ## Instancing
 
-A shell MAY run a napplet as zero or more concurrent instances. A napplet declares how it expects to be instanced with an optional `instancing` tag in its [NIP-5A](5A.md) manifest:
+A napplet states how it expects to be instanced with an optional `instancing` tag in its [NIP-5A](5A.md) manifest:
 
     ["instancing", "<mode>"]
 
 | Mode | Meaning |
 |------|---------|
-| `shared` | Many concurrent instances allowed; all share one shell-mediated scope (e.g. one storage namespace). **Default when the tag is absent.** |
-| `isolated` | Many concurrent instances allowed; each instance is scoped independently, partitioned by its opaque instance discriminator (see [Identity](#identity)). |
-| `singleton` | At most one instance at a time. |
+| `shared` | Many instances, one shared shell-mediated scope (e.g. one storage namespace). **Default when the tag is absent.** |
+| `isolated` | Many instances, each scoped independently by its instance discriminator (see [Identity](#identity)). |
+| `singleton` | At most one instance. |
 
-Like `requires`, the `instancing` tag is defined by this NIP and carried in the NIP-5A manifest event; the NIP-5A static primitive does not interpret it.
+Like `requires`, this tag is defined here and carried in the NIP-5A manifest event; NIP-5A does not interpret it.
 
-**Shell behavior.** Shells SHOULD honor `singleton`: a request to open a napplet that already has a live instance SHOULD focus or reuse that instance rather than create a second one. Shells MAY honor `isolated`; a shell that does not implement per-instance scoping MUST degrade to `shared` (instances share one scope but remain fully functional). An absent or unrecognized mode MUST be treated as `shared`.
+Shells SHOULD honor `singleton` (re-opening focuses the existing instance). Shells MAY honor `isolated`, otherwise degrading to `shared`. An absent or unrecognized mode is `shared`.
 
-**Transparency.** Instancing is invisible to napplet code. A napplet calls every NAP identically in all modes and MUST NOT be able to observe its mode or its instance discriminator. Within a sandboxed iframe all non-persistent state (memory, relay subscriptions, IFC) is already per-instance; `isolated` extends that property to shell-mediated persistent state. How a NAP scopes per-instance state is defined by that NAP (e.g. NAP-STORAGE).
+Instancing is invisible to napplet code: a napplet calls every NAP identically and MUST NOT observe its mode or discriminator. In a sandboxed iframe all non-persistent state (memory, subscriptions, IFC) is already per-instance; `isolated` extends this to shell-mediated persistent state. Each NAP defines how it scopes that state (e.g. NAP-STORAGE).
 
 ## NAP Extension Framework
 
@@ -127,7 +127,7 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 **Mitigations:**
 1. Iframe sandbox: `allow-scripts` is the only required token -- shells MUST NOT add `allow-same-origin`. Adding `allow-same-origin` would grant the napplet a real origin, allowing it to register a service worker, read shell `localStorage`, and bypass shell mediation entirely -- this prohibition is the load-bearing precondition for browser-enforced isolation of any kind.
 2. postMessage `'*'` origin is required for opaque-origin iframes; sender identification uses `MessageEvent.source`, NOT `event.origin`.
-3. Identity binding: the shell maps `MessageEvent.source` to napplet identity at iframe creation. The browser's `MessageEvent.source` is unforgeable within the same browsing context. Distinct instances of one napplet present distinct `Window` sources that map to the same type identity; isolation of per-instance state between them is enforced by the consuming NAP using the shell's opaque instance discriminator, which MUST NOT be exposed to napplets.
+3. Identity binding: the shell maps `MessageEvent.source` to napplet identity at iframe creation; `MessageEvent.source` is unforgeable within the same browsing context. Instances of one napplet present distinct `Window` sources under one type identity; per-instance isolation is enforced by the consuming NAP via the opaque instance discriminator, which MUST NOT be exposed to napplets.
 4. Aggregate hash verification against [NIP-5A](5A.md) manifests; mismatch MAY result in napplet rejection.
 5. Unrecognized message types are silently ignored, preventing capability probing.
 6. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.


### PR DESCRIPTION
## Summary

Adds an optional `["instancing", "<mode>"]` manifest tag to NIP-5D and the runtime semantics for running a napplet as multiple concurrent instances. Motivated by a multi-window use case on the storage seam: a feed napplet wants per-window state (independent pinned-feed tab bars), while other napplets (reading queue, single-state games) want shared or single-instance behavior.

`["instancing", "<mode>"]` carried in the NIP-5A manifest event:

| Mode | Meaning |
|------|---------|
| `shared` | Many instances, one shared scope. **Default when the tag is absent.** |
| `isolated` | Many instances, each scoped independently per instance. |
| `singleton` | At most one instance at a time. |

## Changes

- **Identity** — separate **type identity** `(dTag, aggregateHash)` from a per-`Window` **instance**; many Windows MAY map to one tuple. Introduce an opaque, host-private **instance discriminator** that **MUST NOT** be exposed to the napplet, so napplets stay portable and instance-id-blind.
- **New `Instancing` section** — the three modes and their shell behavior. Shells SHOULD honor `singleton`; MAY honor `isolated` and otherwise degrade to `shared`; absent/unknown mode is treated as `shared`. Instancing is transparent to napplet code.
- **Security** — per-instance isolation is enforced by the consuming NAP using the discriminator; per-`Window` source verification already distinguishes instances.
- **Terminology** — adds `Instance` and `Instance discriminator`.

The tag is **defined here and carried in the NIP-5A manifest event**, mirroring the existing `requires` precedent. **NIP-5A is unchanged.** No transport or wire-envelope change.

## Downstream

Realized by NAP-STORAGE (per-instance storage partitioning in `isolated` mode) — no wire/API change there, prose only.