### PR TITLE
NIP-5D: content-addressed identity and own manifest kinds

### DIFF
--- a/5D.md
+++ b/5D.md
@@ -18,8 +18,9 @@ A napplet is a Nostr applet - a small, focused application that does one thing w
 |------|------------|
 | Shell | Web application hosting napplet iframes |
 | Napplet | Sandboxed iframe application communicating with the shell via postMessage |
-| dTag | Napplet type identifier from the [NIP-5A](5A.md) manifest `d` tag |
-| Aggregate hash | SHA-256 of napplet build files per [NIP-5A](5A.md) |
+| dTag | Napplet identifier from the napplet manifest `d` tag |
+| Aggregate hash | A napplet's content address — `sha256` over its manifest `path` entries (see [Manifest](#manifest)) |
+| Napplet manifest | Nostr event (kind `15129` / `35129`) describing a napplet; tag schema adopted from [NIP-5A](5A.md) |
 | NAP | Nostr Applet Protocol -- extension spec defining protocol messages for a capability domain |
 
 ## Transport
@@ -53,28 +54,37 @@ Messages with an unrecognized `type` MUST be silently ignored. This allows forwa
 
 ## Identity
 
-A napplet is a single self-contained `/index.html`, published per [NIP-5A](5A.md). Its identity is the `(dTag, aggregateHash)` tuple. The runtime **computes** this identity from the napplet's own bytes; it MUST NOT accept it from a host.
+A napplet's identity is the `(dTag, aggregateHash)` tuple. The runtime **computes** it from the napplet's own bytes; it MUST NOT accept it from a host.
 
 Before creating the iframe, the runtime MUST:
 
-1. Resolve the [NIP-5A](5A.md) manifest event from relays and verify its signature.
+1. Resolve the napplet manifest event (kind `15129` or `35129`, see [Manifest](#manifest)) from relays and verify its signature.
 2. Fetch each `path` blob from Blossom by its sha256 and verify `sha256(blob)` matches the `path` hash.
-3. Recompute the aggregate from the `path` tags (per [NIP-5A](5A.md)) and assert it equals the `x` tag; this is `aggregateHash`.
+3. Compute the aggregate over the verified `path` entries; this is `aggregateHash`.
 4. Inject the verified bytes via `srcdoc` (never a navigated `src`) and map the iframe's `Window` reference to `(dTag, aggregateHash)`.
 
 A gateway MAY serve the bytes as an accelerator or fallback, but the runtime MUST verify its output against the signed manifest — the gateway is never trusted.
 
 Identity is thus fixed before any code runs and bound to the exact bytes that run. The shell MUST verify `MessageEvent.source` on every inbound message and silently drop messages from Window references not mapped to a napplet.
 
-## Manifest and NAP Negotiation
+## Manifest
 
-Napplet manifests ([NIP-5A](5A.md) kind 35128) declare required capabilities using `requires` tags:
+A napplet is published as a **napplet manifest** event. Its tag schema is adopted from [NIP-5A](5A.md) (`path`, `server`, and optional `title` / `description` / `source`), under NIP-5D's own kinds:
+
+| Kind | Type | `d` tag |
+|------|------|---------|
+| `15129` | root napplet (replaceable) | none |
+| `35129` | named napplet (addressable) | identifier |
+
+Distinct kinds keep napplets out of nsite gateway resolution: a napplet is resolved and verified by the runtime ([Identity](#identity)), never served as an nsite.
+
+A napplet is a single self-contained `/index.html`. The manifest MUST include a `path` tag per file — `["path", "/index.html", "<sha256>"]` — and `server` tags SHOULD hint the Blossom servers holding those blobs. `aggregateHash` is `sha256` over the `path` entries sorted by path, each rendered as the line `"<path> <sha256>"`.
+
+The manifest declares required capabilities with `requires` tags:
 
     ["requires", "<nap-name>"]
 
-Each `requires` value is a short NAP name matching a NAP domain (e.g., `foo`). Manifests MUST NOT use spec identifiers (e.g., use `foo`, not `NAP-FOO`).
-
-At napplet load time, the shell checks `requires` tags against its own capabilities. If a required capability is absent, the shell SHOULD reject the napplet or display a compatibility warning. If the manifest has no `requires` tags, the shell loads the napplet with whatever capabilities it provides.
+Each value is a bare NAP domain (e.g. `relay`, never `NAP-RELAY`). At load the shell checks `requires` against its capabilities; if one is absent it SHOULD reject the napplet or warn. With no `requires` tags it loads with whatever the shell provides.
 
 ### Runtime Capability Query
 
@@ -113,7 +123,7 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 1. Iframe sandbox: `allow-scripts` is the only required token -- shells MUST NOT add `allow-same-origin`. Adding `allow-same-origin` would grant the napplet a real origin, allowing it to register a service worker, read shell `localStorage`, and bypass shell mediation entirely -- this prohibition is the load-bearing precondition for browser-enforced isolation of any kind.
 2. postMessage `'*'` origin is required for opaque-origin iframes; sender identification uses `MessageEvent.source`, NOT `event.origin`.
 3. Identity binding: the runtime computes `(dTag, aggregateHash)` from the napplet's verified bytes before execution and maps it to the iframe `Window`. `MessageEvent.source` is unforgeable within the same browsing context.
-4. Content-addressed loading: the runtime verifies the manifest signature, each blob's sha256, and the aggregate against the `x` tag (see [Identity](#identity)); a napplet failing any check MUST be rejected. Gateways are untrusted — their output is verified against the signed manifest.
+4. Content-addressed loading: the runtime verifies the manifest signature and each blob's sha256, then computes `aggregateHash` from the verified `path` entries (see [Identity](#identity)); a napplet failing any check MUST be rejected. Gateways are untrusted — their output is verified against the signed manifest.
 5. Unrecognized message types are silently ignored, preventing capability probing.
 6. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
 
@@ -125,4 +135,4 @@ Storage isolation, relay access control, and ACL enforcement are defined by thei
 
 ## References
 
-- [NIP-5A](5A.md) -- Napplet manifest format and aggregate hash
+- [NIP-5A](5A.md) -- manifest tag schema adopted by the napplet manifest

--- a/5D.md
+++ b/5D.md
@@ -26,7 +26,7 @@ A napplet is a Nostr applet - a small, focused application that does one thing w
 
 Communication uses `postMessage`. Napplet to shell: `window.parent.postMessage(msg, '*')`. Shell to napplet: `iframeWindow.postMessage(msg, '*')`. The `'*'` target origin is required because napplets have opaque origins (no `allow-same-origin`).
 
-Napplet iframes MUST use this sandbox attribute:
+Napplet iframes are loaded via `srcdoc` (see [Identity](#identity)) and MUST use this sandbox attribute:
 
     sandbox="allow-scripts"
 
@@ -53,11 +53,18 @@ Messages with an unrecognized `type` MUST be silently ignored. This allows forwa
 
 ## Identity
 
-The shell assigns napplet identity at iframe creation time. No negotiation is required.
+A napplet is a single self-contained `/index.html`, published per [NIP-5A](5A.md). Its identity is the `(dTag, aggregateHash)` tuple. The runtime **computes** this identity from the napplet's own bytes; it MUST NOT accept it from a host.
 
-When the shell creates a napplet iframe, it maps the iframe's `Window` reference to the napplet's `(dTag, aggregateHash)` tuple from the [NIP-5A](5A.md) manifest. This mapping is the napplet's identity for the session. How the shell internally represents or derives identity is an implementation detail.
+Before creating the iframe, the runtime MUST:
 
-The shell MUST verify `MessageEvent.source` on every inbound message. Messages from Window references not mapped to a napplet identity MUST be silently dropped.
+1. Resolve the [NIP-5A](5A.md) manifest event from relays and verify its signature.
+2. Fetch each `path` blob from Blossom by its sha256 and verify `sha256(blob)` matches the `path` hash.
+3. Recompute the aggregate from the `path` tags (per [NIP-5A](5A.md)) and assert it equals the `x` tag; this is `aggregateHash`.
+4. Inject the verified bytes via `srcdoc` (never a navigated `src`) and map the iframe's `Window` reference to `(dTag, aggregateHash)`.
+
+A gateway MAY serve the bytes as an accelerator or fallback, but the runtime MUST verify its output against the signed manifest — the gateway is never trusted.
+
+Identity is thus fixed before any code runs and bound to the exact bytes that run. The shell MUST verify `MessageEvent.source` on every inbound message and silently drop messages from Window references not mapped to a napplet.
 
 ## Manifest and NAP Negotiation
 
@@ -105,8 +112,8 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 **Mitigations:**
 1. Iframe sandbox: `allow-scripts` is the only required token -- shells MUST NOT add `allow-same-origin`. Adding `allow-same-origin` would grant the napplet a real origin, allowing it to register a service worker, read shell `localStorage`, and bypass shell mediation entirely -- this prohibition is the load-bearing precondition for browser-enforced isolation of any kind.
 2. postMessage `'*'` origin is required for opaque-origin iframes; sender identification uses `MessageEvent.source`, NOT `event.origin`.
-3. Identity binding: the shell maps `MessageEvent.source` to napplet identity at iframe creation. The browser's `MessageEvent.source` is unforgeable within the same browsing context.
-4. Aggregate hash verification against [NIP-5A](5A.md) manifests; mismatch MAY result in napplet rejection.
+3. Identity binding: the runtime computes `(dTag, aggregateHash)` from the napplet's verified bytes before execution and maps it to the iframe `Window`. `MessageEvent.source` is unforgeable within the same browsing context.
+4. Content-addressed loading: the runtime verifies the manifest signature, each blob's sha256, and the aggregate against the `x` tag (see [Identity](#identity)); a napplet failing any check MUST be rejected. Gateways are untrusted — their output is verified against the signed manifest.
 5. Unrecognized message types are silently ignored, preventing capability probing.
 6. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
 

--- a/5D.md
+++ b/5D.md
@@ -106,7 +106,7 @@ Napplets MUST gracefully degrade when a capability is absent.
 
 ## NAP Extension Framework
 
-Protocol messages are defined by NAP (Nostr Applet Protocol) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for envelope format and transport. NAPs are defined and registered in the NAP track: <https://github.com/napplet/naps>.
+Protocol messages are defined by [NAP (Nostr Applet Protocol)](https://github.com/napplet/naps) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for envelope format and transport.
 
 For example, a NAP named `foo` would own all `foo.*` message types (e.g., `foo.bar`, `foo.bar.result`) and define their payloads and shell behavior.
 

--- a/5D.md
+++ b/5D.md
@@ -19,8 +19,8 @@ A napplet is a Nostr applet - a small, focused application that does one thing w
 | Shell | Web application hosting napplet iframes |
 | Napplet | Sandboxed iframe application communicating with the shell via postMessage |
 | dTag | Napplet identifier from the napplet manifest `d` tag |
-| Aggregate hash | A napplet's content address — `sha256` over its manifest `path` entries (see [Manifest](#manifest)) |
-| Napplet manifest | Nostr event (kind `15129` / `35129`) describing a napplet; tag schema adopted from [NIP-5A](5A.md) |
+| Aggregate hash | A napplet's content address — the [NIP-5A](5A.md) aggregate hash of its `path` tags, carried in the manifest `x` tag |
+| Napplet manifest | Nostr event (kind `5129` / `15129` / `35129`) describing a napplet; tag schema adopted from [NIP-5A](5A.md) |
 | NAP | Nostr Applet Protocol -- extension spec defining protocol messages for a capability domain |
 
 ## Transport
@@ -58,9 +58,9 @@ A napplet's identity is the `(dTag, aggregateHash)` tuple. The runtime **compute
 
 Before creating the iframe, the runtime MUST:
 
-1. Resolve the napplet manifest event (kind `15129` or `35129`, see [Manifest](#manifest)) from relays and verify its signature.
+1. Resolve the napplet manifest event (kind `5129`, `15129`, or `35129`, see [Manifest](#manifest)) from relays and verify its signature.
 2. Fetch each `path` blob from Blossom by its sha256 and verify `sha256(blob)` matches the `path` hash.
-3. Compute the aggregate over the verified `path` entries; this is `aggregateHash`.
+3. Recompute the aggregate hash from the `path` tags per [NIP-5A](5A.md); if the manifest carries an `x` tag it MUST match. This is `aggregateHash`.
 4. Inject the verified bytes via `srcdoc` (never a navigated `src`) and map the iframe's `Window` reference to `(dTag, aggregateHash)`.
 
 A gateway MAY serve the bytes as an accelerator or fallback, but the runtime MUST verify its output against the signed manifest — the gateway is never trusted.
@@ -69,16 +69,17 @@ Identity is thus fixed before any code runs and bound to the exact bytes that ru
 
 ## Manifest
 
-A napplet is published as a **napplet manifest** event. Its tag schema is adopted from [NIP-5A](5A.md) (`path`, `server`, and optional `title` / `description` / `source`), under NIP-5D's own kinds:
+A napplet is published as a **napplet manifest** event. Its tag schema is adopted from [NIP-5A](5A.md) — `path`, the `x` aggregate tag, `server`, and optional `title` / `description` / `source` — under NIP-5D's own kinds:
 
 | Kind | Type | `d` tag |
 |------|------|---------|
+| `5129` | snapshot (regular) | none |
 | `15129` | root napplet (replaceable) | none |
 | `35129` | named napplet (addressable) | identifier |
 
 Distinct kinds keep napplets out of nsite gateway resolution: a napplet is resolved and verified by the runtime ([Identity](#identity)), never served as an nsite.
 
-A napplet is a single self-contained `/index.html`. The manifest MUST include a `path` tag per file — `["path", "/index.html", "<sha256>"]` — and `server` tags SHOULD hint the Blossom servers holding those blobs. `aggregateHash` is `sha256` over the `path` entries sorted by path, each rendered as the line `"<path> <sha256>"`.
+A napplet is a single self-contained `/index.html`. The manifest MUST include a `path` tag per file — `["path", "/index.html", "<sha256>"]` — and `server` tags SHOULD hint the Blossom servers holding those blobs. `aggregateHash` is the [NIP-5A](5A.md) aggregate hash of the `path` tags, carried in the `x` tag (`["x", "<sha256-hex>", "aggregate"]`). A `5129` snapshot is a regular event pinning a specific napplet version, per [NIP-5A](5A.md).
 
 The manifest declares required capabilities with `requires` tags:
 
@@ -123,7 +124,7 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 1. Iframe sandbox: `allow-scripts` is the only required token -- shells MUST NOT add `allow-same-origin`. Adding `allow-same-origin` would grant the napplet a real origin, allowing it to register a service worker, read shell `localStorage`, and bypass shell mediation entirely -- this prohibition is the load-bearing precondition for browser-enforced isolation of any kind.
 2. postMessage `'*'` origin is required for opaque-origin iframes; sender identification uses `MessageEvent.source`, NOT `event.origin`.
 3. Identity binding: the runtime computes `(dTag, aggregateHash)` from the napplet's verified bytes before execution and maps it to the iframe `Window`. `MessageEvent.source` is unforgeable within the same browsing context.
-4. Content-addressed loading: the runtime verifies the manifest signature and each blob's sha256, then computes `aggregateHash` from the verified `path` entries (see [Identity](#identity)); a napplet failing any check MUST be rejected. Gateways are untrusted — their output is verified against the signed manifest.
+4. Content-addressed loading: the runtime verifies the manifest signature and each blob's sha256, then recomputes the aggregate from the `path` tags and asserts it equals any `x` tag (see [Identity](#identity)); a napplet failing any check MUST be rejected. Gateways are untrusted — their output is verified against the signed manifest.
 5. Unrecognized message types are silently ignored, preventing capability probing.
 6. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
 

--- a/5D.md
+++ b/5D.md
@@ -106,7 +106,7 @@ Napplets MUST gracefully degrade when a capability is absent.
 
 ## NAP Extension Framework
 
-Protocol messages are defined by NAP (Nostr Applet Protocol) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for envelope format and transport.
+Protocol messages are defined by NAP (Nostr Applet Protocol) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for envelope format and transport. NAPs are defined and registered in the NAP track: <https://github.com/napplet/naps>.
 
 For example, a NAP named `foo` would own all `foo.*` message types (e.g., `foo.bar`, `foo.bar.result`) and define their payloads and shell behavior.
 
@@ -137,3 +137,4 @@ Storage isolation, relay access control, and ACL enforcement are defined by thei
 ## References
 
 - [NIP-5A](5A.md) -- manifest tag schema adopted by the napplet manifest
+- [NAPs](https://github.com/napplet/naps) -- NAP interface and message-protocol registry


### PR DESCRIPTION
## Summary

Two related shifts, per the change in direction discussed on nostr-protocol/nips#2303:

1. **Identity is computed by the runtime from the napplet's own bytes**, not received from a host — closing the gap of obtaining `aggregateHash` and binding identity to the exact bytes that run. Opaque origins are preserved (load via `srcdoc`), so the sandbox and shell-mediated storage model are unchanged.
2. **NIP-5D defines its own manifest kinds** instead of reusing NIP-5A's, because napplets aren't gateway-resolvable as nsites. The tag schema is adopted from NIP-5A (incl. the `x` aggregate tag); only the kinds differ.

## Changes

- **Kinds** — `5129` (snapshot) / `15129` (root) / `35129` (named), mirroring NIP-5A's `5128` / `15128` / `35128`. Verified unused on relay.damus.io, nos.lol, relay.primal.net, relay.wellorder.net, nostr.oxtr.dev and unreserved in the kind index.
- **Manifest** — new self-contained section: own kinds, adopted NIP-5A tag schema (`path`, `x`, `server`, optional `title`/`description`/`source`), and `requires`. Distinct kinds keep napplets out of nsite gateway resolution.
- **Identity** — runtime resolution/verification: resolve + verify the manifest event signature, fetch each `path` blob from Blossom by sha256, recompute the aggregate from `path` tags and assert it equals any `x` tag, inject via `srcdoc`, map `Window` → `(dTag, aggregateHash)`. Gateways are optional, verified accelerators.
- **Transport / Security** — napplets load via `srcdoc`; content-addressed checks (signature, blob sha256, aggregate vs `x`) are MUST, failure → reject; gateways untrusted.

Aggregate hash and the `x` tag are per NIP-5A (#2287); this NIP references that computation rather than redefining it.