### PR TITLE
NIP-5D: clarify injected domain bootstrap

### DIFF
--- a/5D.md
+++ b/5D.md
@@ -6,7 +6,7 @@ Nostr Web Applets
 
 `draft` `optional`
 
-This NIP defines a protocol for sandboxed web applications ("napplets") running in iframes to communicate with a hosting application ("shell") via postMessage using a generic JSON envelope. Protocol messages are defined by NAP (Nostr Applet Protocol) extension specs.
+This NIP defines a web projection for sandboxed web applications ("napplets") running in iframes to communicate with a hosting application ("shell"). Shells expose granted NAP (Nostr Applet Protocol) domains through an injected `window.napplet` namespace. Under that namespace, domain calls are carried over `postMessage` using a generic JSON envelope. Protocol messages are defined by NAP extension specs.
 
 ## Philosophy
 
@@ -25,7 +25,7 @@ A napplet is a Nostr applet - a small, focused application that does one thing w
 
 ## Transport
 
-Communication uses `postMessage`. Napplet to shell: `window.parent.postMessage(msg, '*')`. Shell to napplet: `iframeWindow.postMessage(msg, '*')`. The `'*'` target origin is required because napplets have opaque origins (no `allow-same-origin`).
+Communication uses an injected `window.napplet` namespace backed by `postMessage`. Napplet to shell: `window.parent.postMessage(msg, '*')`. Shell to napplet: `iframeWindow.postMessage(msg, '*')`. The `'*'` target origin is required because napplets have opaque origins (no `allow-same-origin`).
 
 Napplet iframes are loaded via `srcdoc` (see [Identity](#identity)) and MUST use this sandbox attribute:
 
@@ -34,6 +34,8 @@ Napplet iframes are loaded via `srcdoc` (see [Identity](#identity)) and MUST use
 The `allow-same-origin` token MUST NOT be present. Shells MAY add additional sandbox tokens (`allow-forms`, `allow-modals`, `allow-downloads`, `allow-popups`) based on shell policy. Napplets have no access to `localStorage`, `sessionStorage`, `IndexedDB`, direct WebSocket connections, or signing keys. All storage, signing, encryption, and relay access is proxied through the shell.
 
 The shell identifies senders via `MessageEvent.source` (unforgeable Window reference). Messages from unknown sources (iframes not created by the shell) MUST be silently dropped.
+
+Shells MUST inject `window.napplet` before any napplet script runs, including classic scripts, module scripts, reloads, and development wrappers. The namespace MUST contain only the NAP domain objects the shell exposes to that napplet. Presence of a domain object means that domain is available to the napplet. Absence means unavailable.
 
 Shells MUST NOT provide `window.nostr` (NIP-07) to napplet iframes. Signing and encryption are security-critical operations that MUST be mediated by the shell. See the Security Rationale section below.
 
@@ -87,26 +89,15 @@ The manifest declares required capabilities with `requires` tags:
 
 Each value is a bare NAP domain (e.g. `relay`, never `NAP-RELAY`). At load the shell checks `requires` against its capabilities; if one is absent it SHOULD reject the napplet or warn. With no `requires` tags it loads with whatever the shell provides.
 
-### Runtime Capability Query
+### Runtime Domain Availability
 
-Napplets query capability support at runtime:
+Napplets detect runtime domain availability from the injected namespace. If `window.napplet.<domain>` is present, the shell exposes that NAP domain to the napplet. If it is absent, the napplet MUST gracefully degrade or stop using that domain.
 
-    window.napplet.shell.supports('foo')           // NAP capability — boolean
-    window.napplet.shell.supports('perm:popups')   // permission — boolean
-
-Shells MUST implement `window.napplet.shell.supports()`. The argument is a namespaced capability string:
-
-| Prefix   | Example            | Meaning                         |
-|----------|--------------------|---------------------------------|
-| *(bare)* | `'relay'`          | Shorthand for `'nap:relay'`     |
-| `nap:`   | `'nap:identity'`   | Shell implements the identity NAP |
-| `perm:`  | `'perm:popups'`    | Shell grants popup permission   |
-
-Napplets MUST gracefully degrade when a capability is absent.
+Domain object presence is only an availability signal. It does not define the domain's operations, payloads, error model, version support, or semantics. Those contracts remain in the matching NAP specs. If a domain needs semantic compatibility checks, version negotiation, or diagnostics, that domain MUST define them in its own NAP.
 
 ## NAP Extension Framework
 
-Protocol messages are defined by [NAP (Nostr Applet Protocol)](https://github.com/napplet/naps) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for envelope format and transport.
+Protocol messages are defined by [NAP (Nostr Applet Protocol)](https://github.com/napplet/naps) specs. Each NAP owns a message domain and defines the `type` strings, payload shapes, injected domain object behavior, and semantics for that domain. A NAP spec is self-contained — it references this NIP only for web namespace injection, envelope format, and transport.
 
 For example, a NAP named `foo` would own all `foo.*` message types (e.g., `foo.bar`, `foo.bar.result`) and define their payloads and shell behavior.
 
@@ -125,8 +116,9 @@ Napplets are untrusted code. The shell is trusted. The browser enforces iframe s
 2. postMessage `'*'` origin is required for opaque-origin iframes; sender identification uses `MessageEvent.source`, NOT `event.origin`.
 3. Identity binding: the runtime computes `(dTag, aggregateHash)` from the napplet's verified bytes before execution and maps it to the iframe `Window`. `MessageEvent.source` is unforgeable within the same browsing context.
 4. Content-addressed loading: the runtime verifies the manifest signature and each blob's sha256, then recomputes the aggregate from the `path` tags and asserts it equals any `x` tag (see [Identity](#identity)); a napplet failing any check MUST be rejected. Gateways are untrusted — their output is verified against the signed manifest.
-5. Unrecognized message types are silently ignored, preventing capability probing.
-6. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
+5. Runtime injection is outside the signed napplet artifact. It MUST be limited to the `window.napplet` namespace and MUST NOT change the napplet bytes used to compute `aggregateHash`.
+6. Unrecognized message types are silently ignored, preventing capability probing.
+7. Napplets produce cleartext only. Shells MUST NOT sign or broadcast events containing ciphertext received from a napplet. Shells MUST NOT provide `window.nostr` (NIP-07) or any signing/encryption primitives.
 
 Storage isolation, relay access control, and ACL enforcement are defined by their respective NAP specs.
 
@@ -135,4 +127,4 @@ Storage isolation, relay access control, and ACL enforcement are defined by thei
 ## References
 
 - [NIP-5A](5A.md) -- manifest tag schema adopted by the napplet manifest
-- [NAPs](https://github.com/napplet/naps) -- NAP interface and message-protocol registry
+- [NAPs](https://github.com/napplet/naps) -- NAP domain and message-protocol registry


### PR DESCRIPTION
## Summary

Clarifies NIP-5D as the web projection bootstrap: shells inject `window.napplet` and expose granted domain objects there, while NAP specs retain the per-domain operation, version, diagnostic, payload, and error contracts. This implements the positive direction from https://github.com/napplet/naps/discussions/57 without changing NIP-5A manifest semantics.

## Changes

- Makes injected `window.napplet` timing and domain-object availability normative.
- Removes the concrete `window.napplet.shell.supports()` examples and `perm:*` capability prefix.
- States that domain object presence is only availability, not semantic compatibility or version negotiation.
- Names runtime injection as outside the signed napplet artifact and limited to `window.napplet`.

## Downstream

NAP specs remain the source of truth for per-domain behavior. NIP-5A remains manifest-only and unchanged.