### PR TITLE
Keep NIP-5D sandbox baseline narrow

### DIFF
--- a/5D.md
+++ b/5D.md
@@ -31,7 +31,7 @@ Napplet iframes are loaded via `srcdoc` (see [Identity](#identity)) and MUST use
 
     sandbox="allow-scripts"
 
-The `allow-same-origin` token MUST NOT be present. Shells MAY add additional sandbox tokens (`allow-forms`, `allow-modals`, `allow-downloads`, `allow-popups`) based on shell policy. Napplets have no access to `localStorage`, `sessionStorage`, `IndexedDB`, direct WebSocket connections, or signing keys. All storage, signing, encryption, and relay access is proxied through the shell.
+The `allow-same-origin` token MUST NOT be present. Napplets have no access to `localStorage`, `sessionStorage`, `IndexedDB`, direct WebSocket connections, or signing keys. All storage, signing, encryption, and relay access is proxied through the shell.
 
 The shell identifies senders via `MessageEvent.source` (unforgeable Window reference). Messages from unknown sources (iframes not created by the shell) MUST be silently dropped.
 


### PR DESCRIPTION
## Summary

- remove the sentence allowing shells to add `allow-forms`, `allow-modals`, `allow-downloads`, and `allow-popups`
- keep the required `allow-scripts` baseline and `allow-same-origin` prohibition intact

## Rationale

These additional sandbox tokens are ambient browser affordances rather than NIP-5D interoperability requirements. Leaving them out keeps the web projection focused on the minimum sandbox baseline and avoids implying that napplets can rely on shell-specific sandbox relaxations.

## Validation

- `git diff --check --cached`
- verified the removed sandbox-token sentence no longer appears in `5D.md`
